### PR TITLE
fix minor spelling mistake which caused download failure on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var progress = require('progress-stream');
 var semver = require('semver');
 
 var platform = process.platform === 'darwin' ? 'osx' : 
-  process.platform === 'win3' ? 'win' : process.platform;
+  process.platform === 'win32' ? 'win' : process.platform;
 
 var ext = platform === 'linux' ? '.tar.gz' : '.zip';
 


### PR DESCRIPTION
'win32' is misspelled as 'win3', and it makes wrong download link on windows. This simple fix should get things working.
